### PR TITLE
Improvements in RDS Schema

### DIFF
--- a/code/sql/schema.sql
+++ b/code/sql/schema.sql
@@ -1,5 +1,14 @@
 CREATE SCHEMA waze;
 
+CREATE TABLE waze.signals
+(
+"id"                                BIGINT PRIMARY KEY NOT NULL,
+"date_start"                        TIMESTAMP WITH TIME ZONE,
+"date_end"                          TIMESTAMP WITH TIME ZONE,
+CONSTRAINT "unique_date_start"      UNIQUE("date_start"),
+CONSTRAINT "unique_date_end"      UNIQUE("date_end")
+);
+
 CREATE TABLE waze.jams 
 (
   "id"                  BIGINT PRIMARY KEY NOT NULL,
@@ -18,6 +27,28 @@ CREATE TABLE waze.jams
   "level"               INTEGER,
   "blocking_alert_id"   VARCHAR[500]
 );
+
+    id = Column("JamId", Integer, primary_key=True)
+    object_id = Column("JamObjectId", Unicode)
+    dateStart = Column("JamDateStart", DateTime(timezone=True),
+                       ForeignKey("MongoRecord.MgrcDateStart", ondelete="CASCADE"), nullable=False)
+    dateEnd = Column("JamDateEnd", DateTime(timezone=True))
+    city = Column("JamDscCity", Unicode)
+    coords = Column("JamDscCoordinatesLonLat", typeJSON)
+    roadType = Column("JamDscRoadType", Integer)
+    segments = Column("JamDscSegments", typeJSON)
+    street = Column("JamDscStreet", Unicode)
+    endNode = Column("JamDscStreetEndNode", Unicode)
+    turnType = Column("JamDscTurnType", Unicode)
+    jam_type = Column("JamDscType", Unicode)
+    level = Column("JamIndLevelOfTraffic", Integer)
+    length = Column("JamQtdLengthMeters", Integer)
+    speed = Column("JamSpdMetersPerSecond", Float)
+    delay = Column("JamTimeDelayInSeconds", Integer)
+    pubMillis = Column("JamTimePubMillis", BigInteger)
+    uuid = Column("JamUuid", Integer)
+    
+    __table_args__ = (UniqueConstraint("JamDateStart", "JamUuid", name="JamDateUuid"),)
 
 CREATE TABLE waze.alerts 
 (

--- a/code/sql/schema.sql
+++ b/code/sql/schema.sql
@@ -3,52 +3,32 @@ CREATE SCHEMA waze;
 CREATE TABLE waze.signals
 (
 "id"                                BIGINT PRIMARY KEY NOT NULL,
+"startTimeMillis"                   BIGINT UNIQUE NOT NULL,
+"endTimeMillis"                     BIGINT NOT NULL,
 "date_start"                        TIMESTAMP WITH TIME ZONE,
-"date_end"                          TIMESTAMP WITH TIME ZONE,
-CONSTRAINT "unique_date_start"      UNIQUE("date_start"),
-CONSTRAINT "unique_date_end"      UNIQUE("date_end")
+"date_end"                          TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE waze.jams 
 (
-  "id"                  BIGINT PRIMARY KEY NOT NULL,
-  "uuid"                VARCHAR[500] NOT NULL,
-  "pub_millis"          BIGINT NOT NULL,
-  "start_node"          VARCHAR[500],
-  "end_node"            VARCHAR[500],
-  "road_type"           INTEGER,
-  "street"              VARCHAR[500],
-  "city"                VARCHAR[500],
-  "country"             VARCHAR[500],
-  "delay"               INTEGER,
-  "speed"               float4,
-  "length"              INTEGER,
-  "turn_type"           VARCHAR[500],
-  "level"               INTEGER,
-  "blocking_alert_id"   VARCHAR[500]
+  "id"                              BIGINT PRIMARY KEY NOT NULL,
+  "uuid"                            VARCHAR[500] NOT NULL,
+  "pub_millis"                      BIGINT NOT NULL,
+  "start_node"                      VARCHAR[500],
+  "end_node"                        VARCHAR[500],
+  "road_type"                       INTEGER,
+  "street"                          VARCHAR[500],
+  "city"                            VARCHAR[500],
+  "country"                         VARCHAR[500],
+  "delay"                           INTEGER,
+  "speed"                           float4,
+  "length"                          INTEGER,
+  "turn_type"                       VARCHAR[500],
+  "level"                           INTEGER,
+  "blocking_alert_id"               VARCHAR[500],
+  "coordinates"                     JSON,
+  "signal_id"                       BIGINT NOT NULL REFERENCES waze.signals (id)
 );
-
-    id = Column("JamId", Integer, primary_key=True)
-    object_id = Column("JamObjectId", Unicode)
-    dateStart = Column("JamDateStart", DateTime(timezone=True),
-                       ForeignKey("MongoRecord.MgrcDateStart", ondelete="CASCADE"), nullable=False)
-    dateEnd = Column("JamDateEnd", DateTime(timezone=True))
-    city = Column("JamDscCity", Unicode)
-    coords = Column("JamDscCoordinatesLonLat", typeJSON)
-    roadType = Column("JamDscRoadType", Integer)
-    segments = Column("JamDscSegments", typeJSON)
-    street = Column("JamDscStreet", Unicode)
-    endNode = Column("JamDscStreetEndNode", Unicode)
-    turnType = Column("JamDscTurnType", Unicode)
-    jam_type = Column("JamDscType", Unicode)
-    level = Column("JamIndLevelOfTraffic", Integer)
-    length = Column("JamQtdLengthMeters", Integer)
-    speed = Column("JamSpdMetersPerSecond", Float)
-    delay = Column("JamTimeDelayInSeconds", Integer)
-    pubMillis = Column("JamTimePubMillis", BigInteger)
-    uuid = Column("JamUuid", Integer)
-    
-    __table_args__ = (UniqueConstraint("JamDateStart", "JamUuid", name="JamDateUuid"),)
 
 CREATE TABLE waze.alerts 
 (
@@ -67,8 +47,7 @@ CREATE TABLE waze.alerts
   "subtype"                       VARCHAR[500],
   "report_by_municipality_user"   BOOLEAN,
   "thumbs_up"                     INTEGER,
-  "jam_id"                        VARCHAR[500] REFERENCES waze.jams (uuid),
-  "irregularity_id"               VARCHAR[500] REFERENCES waze.irregularities (uuid)
+  "signal_id"                     BIGINT NOT NULL REFERENCES waze.signals (id)
 );
 
 CREATE TABLE waze.irregularities 
@@ -96,7 +75,8 @@ CREATE TABLE waze.irregularities
   "alerts_count"            INTEGER,
   "n_thumbs_up"             INTEGER,
   "n_comments"              INTEGER,
-  "n_images"                INTEGER
+  "n_images"                INTEGER,
+  "signal_id"               BIGINT NOT NULL REFERENCES waze.signals (id)
 );
 
 
@@ -124,4 +104,3 @@ CREATE TABLE waze.alert_types
   "type"      VARCHAR[500] NOT NULL,
   "subtype"   VARCHAR[500]
 );
-


### PR DESCRIPTION
Hi. See below changes and justifications:

1 - Create table "signals", referenced by tables "jams", "alerts" and "irregularities"
- This will keep track of all Waze data, regardless of them containing any jams, alerts or irregularities. Empty signals are also important for analyses.
- It may be used to avoid duplicates (storing the same document twice in the database)
- It's also a way to store the document date (not pubmillis), absent in the current schema
- It's a way of including an enriched field with TIMESTAMP WITH TIMEZONE type without messing with the other table schemas.

2 - Added "jams.coordinates" JSON field (which actually stores an ordered list)
- Makes it easier to calculate jam's direction (see sample below)
- Makes it easer to convert the jams into geodataframe (see sample below)
- Geodataframes are very powerful in facilitating spatial joins

3 - Changed foreign keys of table "alerts"
- Could not create the "alerts" table with the original code. Error: 
psql:schema.sql:41: ERROR:  there is no unique constraint matching given keys for referenced table "jams"
The field "alerts.jam_id" references "jams.uuid", which is not required to be UNIQUE.

Sample code (to justify the proposed changes):
```
def get_direction(coord_list):
    try:
      num_coords = len(coord_list)
    except:
      return pd.Series([None, None])
    
    #North/South
    y_start = coord_list[0]["y"]
    y_end = coord_list[num_coords-1]["y"]
    delta_y = (y_end-y_start)
    if delta_y >= 0:
        lat_direction = "North"
    else:
        lat_direction = "South"
        
    #East/West
    x_start = coord_list[0]["x"]
    x_end = coord_list[num_coords-1]["x"]
    delta_x = (x_end-x_start)
    if delta_x >= 0:
        lon_direction = "East"
    else:
        lon_direction = "West"

    #MajorDirection
    if abs(delta_y) > abs(delta_x):
        major_direction = "North/South"
    else:
        major_direction = "East/West"
        
    return pd.Series([lon_direction, lat_direction, major_direction])
```
``` 
import pandas as pd
import geopandas as gpd
from shapely.geometry import LineString

df_jams = pd.read_sql(INSERT HERE YOUR QUERY)
df_jams['jams_line_list'] = df_jams['coordinates'].apply(lambda x: [tuple([d['x'], d['y']]) for d in x])
df_jams['jam_LineString'] = df_jams.apply(lambda x: shapely.geometry.LineString(x['jams_line_list']), axis=1)
df_jams[["LonDirection","LatDirection", "MajorDirection"]] = df_jams["coordinates"].apply(get_direction)
crs = {'init': 'epsg:4326'}
geo_jams = gpd.GeoDataFrame(df_jams, crs=crs, geometry="jam_LineString")
```

